### PR TITLE
Modify require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/mail": "5.1.x",
+        "illuminate/mail": ">=5.1.x",
         "mailjet/mailjet-apiv3-php": "1.0.x"
     },
     "autoload": {


### PR DESCRIPTION
When working with Laravel 5.2.23, Illuminate/Mail v 5.2.\* is used.
Composer update gives  a 'Your requirements could not be resolved to an installable set of packages.' error.
I suppose this can be solved by updating the require to "illuminate/mail": ">=5.1.x" ?
